### PR TITLE
Tweak `docs/` markdown + refinements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,4 @@
-# FreePDM
-***Documentation***
+## FreePDM Documentation
 
 ## Table of Contents
 

--- a/docs/SetupVirtualServer.md
+++ b/docs/SetupVirtualServer.md
@@ -1,17 +1,16 @@
-# FreePDM
-***Documentation***
+## FreePDM Documentation
 
 ## Setup VirtualBox
 
 ### General
 
-For setting up a VM in VirtualBox there are multiple tutorials out in the wild.
+For setting up a Virtual Machine (VM) in VirtualBox there are multiple tutorials out in the wild.
 For example use the one from [it's foss](https://itsfoss.com/install-linux-mint-in-virtualbox/).
 This example is for Linux Mint specifically but the principles are the same for Debian, RedHat and other distros.
 
 ### Network
 
-Before you can have access to your Virtual Machine / Server you have to setup your VM network.
+Before you can have access to your VM/Server you have to setup your VM network.
 Below is a screenshot of the network preference page.
 You have to set it as a 'bridged adapter' and set its name to the network adapter that:
 
@@ -30,7 +29,7 @@ Now you can access your VM via [ssh](#ssh)
 
 ### Setup static IP address
 
-Setting up a _static_ _IP address_ is recommended, but not required.
+A static IP address is an address that doesn't change (as opposed to dynamic IP addresses). Setting up a _static_ _IP address_ is recommended, but not required.
 If preferred to leave the _IP address_ as is, see below how to check your _IP address_.
 For changing the _IP address_ to _static_ one see for example [this blog](https://www.rosehosting.com/blog/how-to-configure-static-ip-address-on-ubuntu-20-04/) or [here](https://linuxconfig.org/how-to-setup-a-static-ip-address-on-debian-linux).
 
@@ -39,18 +38,23 @@ The command `ip -a | grep inet` gives your current (local) _IP address_.
 ![getipaddress](./figures/get_IPadress.png)
 You can access this your server from your _terminal_ or via _Putty_. 
 
-### ssh
+### `ssh`
 
 _ssh_ is a  Secure Shell protocol.
 As long as you have installed it on both your server and on you system you should be able to remote login.
 
-Login works as follows:  
+Login works as follows:
+
 ```shell
 ssh USERNAME@###.###.###.###
-``` 
-then typing in your password, accepting the handshake (if not done before). 
-Then you are ready to go.
+```
+
+Then type in your password. 
 
 ![ssh_login](./figures/ssh_login.png)
+
+Note: if this is the first time connecting via `ssh` you'll be prompted to confirm and accept ssh key 'handshake'. Please agree to this. On subsequent logins this will not be displayed. 
+
+Now you are ready to go.
 
 [<< Previous Chapter](commands.md) | [Content Table](README.md) | [Next Chapter >>]()

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,13 +1,12 @@
-# FreePDM
-***Documentation***
+## FreePDM Documentation
 
-## Code Snippets
-There is no way to add a button, menu entry from python to a workbench which is added with c++. So here is a comparison how to do that with python and with c++.
+### Code Snippets
+There is no way to add a button/menu entry from python to a workbench which is added with cpp (c++). So here is a comparison how to do that with python and with cpp.
 
 ### Adding a command:
-This can be done either with python or c++.
+This can be done either with python or cpp.
 
-#### 1. python
+#### Python
 
 ```python
 import FreeCAD as App
@@ -15,8 +14,8 @@ import FreeCAD as App
 class MyCommand(object):
     def IsActive(self):
         """
-        availability of the command (eg.: check for existence of a document,...)
-        if this function returns False, the menu/ buttons are ßdisabled (gray)
+        availability of the command (eg.: check for existence of a document...)
+        if this function returns False, the menu/buttons are disabled (greyed out)
         """
         if App.ActiveDocument is None:
             return False
@@ -57,9 +56,9 @@ class myWorkbench(Workbench):
         self.appendMenu("Gear", ["MyCommand"])
 ```
 
-#### 2. C++
+#### Cplusplus
 
-```c++
+```cpp
 
 #include <App/Document.h>
 #include <Gui/Command.h>
@@ -88,14 +87,14 @@ void MyCommand::activated(int)
 
 bool MyCommand::isActive(void)
 {
-    // availability of the command (eg.: check for existence of a document,...)
-    // if this function returns False, the menu/ buttons are ßdisabled (gray)
+    // availability of the command (eg.: check for existence of a document...)
+    // if this function returns False the menu/buttons are disabled (greyed out)
     return (hasActiveDocument() && !Gui::Control().activeDialog());
 }
 ```
 To register the command in FreeCAD:
 
-```c++
+```cpp
 #include <Gui/Command.h>
 
 Gui::CommandManager &rcCmdMgr = Gui::Application::Instance->commandManager();
@@ -104,7 +103,7 @@ rcCmdMgr.addCommand(new MyCommand());
 Adding a item to a menu/toolbar:
 
 if your command is added with python you have to run this code:
-in src/module/Gui/AppModuleGui.cpp add to PyMOD_INIT_FUNC:
+in `src/module/Gui/AppModuleGui.cpp` add to `PyMOD_INIT_FUNC`:
 
 ```c++
 // try to instantiate a python module
@@ -115,10 +114,10 @@ try{
 }
 ```
 
-and add the name of the command to a tooltip/menu in src/module/Gui/Workbench.cpp Workbench::setupToolBars
+and add the name of the command to a `tooltip/menu in src/module/Gui/Workbench.cpp` `Workbench::setupToolBars`
 
 
-```c++
+```cpp
 Gui::ToolBarItem* Workbench::setupToolBars() const
 {
     Gui::ToolBarItem* root = StdWorkbench::setupToolBars();

--- a/docs/startup.md
+++ b/docs/startup.md
@@ -1,28 +1,43 @@
-# FreePDM
-***Documentation***
+## FreePDM Documentation
 
-## How to install FreePDM
-FreePDM is a PDM that works outside of FreeCAD. It can deal with FreeCAD files.
+### How to install FreePDM
 
-### Install Python
+FreePDM is a PDM that works external to FreeCAD. It can interoperate with FreeCAD files.
+
+### Preprequisites
+
+#### Python
+
 Since we are working with outside of FreeCAD we need to install Python.
 
 TODO: Show how to
 
-### Install PIP
+#### `pip`
 TODO: Show how to
 
-#### Install PIP modules
+##### `pip` modules
+
+```shell
 pip3 install defusedxml
 pip3 install imageio
+```
 
-### Install CSV
+#### CSV
+
 TODO: Show how to
 
-### Install PostgreSQL
+#### PostgreSQL
+
 TODO: Show how to
 
-### Show icons of FreeCAD files
-Go to: Edit -> Preferences -> General -> Document -> Save thumbnail into project when saving document (and leave the 128 number)
+#### Show icons of FreeCAD files
+
+This option provides the possibility to display a screenshot of the model within the FreeCAD file as the file thumbnail.  
+
+Within FreeCAD:  
+
+`Edit` ➡️ `Preferences` ➡️ `General` ➡️ `Document` ➡️ `Save thumbnail into project when saving document`  
+
+Note: leave the 128 number
 
 [<< Previous Chapter](README.md) | [Content Table](README.md) | [Next Chapter >>](commands.md)


### PR DESCRIPTION
- made headers sections smaller  
- converted section names so they are compatible for url links (c++ to cplusplus)
- used specific code formatting  
- tweaked grammar  